### PR TITLE
Default folders

### DIFF
--- a/bw_projects/filesystem.py
+++ b/bw_projects/filesystem.py
@@ -1,30 +1,43 @@
 import hashlib
+import re
 import os
+import unicodedata
 
+from typing import Union
 from pathlib import Path
 
 
-def create_dir(dirpath):
+re_slugify = re.compile(r"[^\w\s-]", re.UNICODE)
+SUBSTITUTION_RE = re.compile(r"[^\w\-\.]")
+MULTI_RE = re.compile(r"_{2,}")
+
+
+def safe_filename(string: Union[str, bytes], add_hash: bool = True) -> str:
+    """Convert arbitrary strings to make them safe for filenames. Substitutes strange characters, and uses unicode normalization.
+    if `add_hash`, appends hash of `string` to avoid name collisions.
+    From http://stackoverflow.com/questions/295135/turn-a-string-into-a-valid-filename-in-python"""
+    safe = re.sub(
+        r"[-\s]+",
+        "-",
+        str(re_slugify.sub("", unicodedata.normalize("NFKD", str(string))).strip()),
+    )
+    if add_hash:
+        if isinstance(string, str):
+            string = string.encode("utf8")
+        safe += "." + hashlib.md5(string).hexdigest()[:8]
+    return safe
+
+
+def create_dir(dirpath: str) -> None:
     "Create directory tree to `dirpath`; ignore if already exists"
     if not os.path.isdir(dirpath):
         os.makedirs(dirpath)
 
 
-def check_dir(directory):
+def check_dir(directory: str) -> bool:
     """Returns ``True`` if given path is a directory and writeable, ``False`` otherwise."""
     return os.path.isdir(directory) and os.access(directory, os.W_OK)
 
 
-def md5(filepath, blocksize=65536):
-    """Generate MD5 hash for file at `filepath`"""
-    hasher = hashlib.md5()
-    fo = open(filepath, "rb")
-    buf = fo.read(blocksize)
-    while len(buf) > 0:
-        hasher.update(buf)
-        buf = fo.read(blocksize)
-    return hasher.hexdigest()
-
-
-def maybe_path(x):
+def maybe_path(x: str) -> Path:
     return Path(x) if x else x

--- a/bw_projects/project.py
+++ b/bw_projects/project.py
@@ -41,8 +41,8 @@ class ProjectManager(Iterable):
     _is_temp_dir = False
     read_only = False
 
-    def __init__(self):
-        self._base_data_dir, self._base_logs_dir = self._get_base_directories()
+    def __init__(self, folder=None):
+        self._base_data_dir, self._base_logs_dir = self._get_base_directories(folder)
         self._create_base_directories()
         self.db = SubstitutableDatabase(
             self._base_data_dir / "projects.db", [ProjectDataset]
@@ -83,31 +83,28 @@ class ProjectManager(Iterable):
             )
 
     ### Internal functions for managing projects
-
-    def _get_base_directories(self):
-        envvar = maybe_path(os.getenv("BRIGHTWAY2_DIR"))
-        if envvar:
+    def _get_base_directories(self, folder=None):
+        if folder:
+            envvar = maybe_path(folder)
             if not envvar.is_dir():
-                raise OSError(
-                    (
-                        "BRIGHTWAY2_DIR variable is {}, but this is not"
-                        " a valid directory"
-                    ).format(envvar)
-                )
-            else:
-                print(
-                    "Using environment variable BRIGHTWAY2_DIR for data "
-                    "directory:\n{}".format(envvar)
-                )
-                envvar = envvar.absolute()
-                logs_dir = envvar / "logs"
-                create_dir(logs_dir)
-                return envvar, logs_dir
-
-        LABEL = "Brightway3"
-        data_dir = Path(appdirs.user_data_dir(LABEL, "pylca"))
-        logs_dir = Path(appdirs.user_log_dir(LABEL, "pylca"))
-        return data_dir, logs_dir
+                create_dir(envvar)
+            envvar = envvar.absolute()
+            logs_dir = envvar / "logs"
+            create_dir(logs_dir)
+            return envvar, logs_dir
+        elif os.getenv("BRIGHTWAY_DIR"):
+            envvar = maybe_path(os.getenv("BRIGHTWAY_DIR"))
+            if not envvar.is_dir():
+                create_dir(envvar)
+            envvar = envvar.absolute()
+            logs_dir = envvar / "logs"
+            create_dir(logs_dir)
+            return envvar, logs_dir
+        else:
+            LABEL = "Brightway3"
+            data_dir = Path(appdirs.user_data_dir(LABEL, "pylca"))
+            logs_dir = Path(appdirs.user_log_dir(LABEL, "pylca"))
+            return data_dir, logs_dir
 
     def _create_base_directories(self):
         create_dir(self._base_data_dir)
@@ -128,15 +125,11 @@ class ProjectManager(Iterable):
     ### Public API
     @property
     def dir(self) -> Path:
-        return Path(self._base_data_dir) / safe_filename(
-            self.current, full=self.dataset.full_hash
-        )
+        return Path(self._base_data_dir) / safe_filename(self.current)
 
     @property
     def logs_dir(self) -> Path:
-        return Path(self._base_logs_dir) / safe_filename(
-            self.current, full=self.dataset.full_hash
-        )
+        return Path(self._base_logs_dir) / safe_filename(self.current)
 
     @property
     def output_dir(self) -> Path:
@@ -164,9 +157,7 @@ class ProjectManager(Iterable):
         try:
             self.dataset = ProjectDataset.get(ProjectDataset.name == name)
         except DoesNotExist:
-            self.dataset = ProjectDataset.create(
-                data=kwargs, name=name
-            )
+            self.dataset = ProjectDataset.create(data=kwargs, name=name)
         create_dir(self.dir)
         for dir_name in self._basic_directories:
             create_dir(self.dir / dir_name)
@@ -176,13 +167,11 @@ class ProjectManager(Iterable):
         """Copy current project to a new project named ``new_name``. If ``switch``, switch to new project."""
         if new_name in self:
             raise ValueError("Project {} already exists".format(new_name))
-        fp = self._base_data_dir / safe_filename(new_name, full=self.dataset.full_hash)
+        fp = self._base_data_dir / safe_filename(new_name)
         if fp.exists():
             raise ValueError("Project directory already exists")
         project_data = ProjectDataset.get(ProjectDataset.name == self.current).data
-        ProjectDataset.create(
-            data=project_data, name=new_name, full_hash=self.dataset.full_hash
-        )
+        ProjectDataset.create(data=project_data, name=new_name)
         shutil.copytree(self.dir, fp, ignore=lambda x, y: ["write-lock"])
         create_dir(self._base_logs_dir / safe_filename(new_name))
         if switch:
@@ -275,11 +264,8 @@ class ProjectManager(Iterable):
         return len(bad_directories)
 
     def use_short_hash(self):
-        if not self.dataset.full_hash:
-            return
         try:
             old_dir, old_logs_dir = self.dir, self.logs_dir
-            self.dataset.full_hash = False
             if self.dir.exists():
                 raise OSError("Target directory {} already exists".format(self.dir))
             if self.logs_dir.exists():
@@ -290,15 +276,11 @@ class ProjectManager(Iterable):
             old_logs_dir.rename(self.logs_dir)
             self.dataset.save()
         except Exception as ex:
-            self.dataset.full_hash = True
             raise ex
 
     def use_full_hash(self):
-        if self.dataset.full_hash:
-            return
         try:
             old_dir, old_logs_dir = self.dir, self.logs_dir
-            self.dataset.full_hash = True
             if self.dir.exists():
                 raise OSError("Target directory {} already exists".format(self.dir))
             if self.logs_dir.exists():
@@ -309,7 +291,6 @@ class ProjectManager(Iterable):
             old_logs_dir.rename(self.logs_dir)
             self.dataset.save()
         except Exception as ex:
-            self.dataset.full_hash = False
             raise ex
 
 

--- a/bw_projects/project.py
+++ b/bw_projects/project.py
@@ -7,11 +7,10 @@ from pathlib import Path
 from threading import ThreadError
 
 import appdirs
-from bw_processing import safe_filename
 from peewee import BooleanField, DoesNotExist, Model, TextField
 
 from . import config
-from .filesystem import create_dir, maybe_path
+from .filesystem import create_dir, maybe_path, safe_filename
 from .sqlite import PickleField, SubstitutableDatabase
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 appdirs
-bw_processing
 peewee>=3.9.4

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     license="3-clause BSD",
     install_requires=[
         "appdirs",
-        "bw_processing",
         "peewee>=3.9.4",
     ],
     url="https://github.com/baali/bw_projects.git",

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,136 @@
+import os
+import random
+import shutil
+import string
+import sys
+import tempfile
+import unittest
+
+from pathlib import Path
+
+from bw_projects.project import ProjectManager, ProjectDataset
+from bw_projects.filesystem import maybe_path, create_dir, check_dir, safe_filename
+from bw_projects import projects
+
+
+class TestProjects(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = projects._use_temp_directory()
+        self.current = "".join(random.choices(string.ascii_lowercase, k=18))
+        self.assertEqual("default", projects.current)
+        projects.set_current(self.current)
+        self.assertEqual(self.current, projects.current)
+        self.projects = projects
+
+    def tearDown(self):
+        if hasattr(self.projects, "_lock"):
+            try:
+                self.projects._lock.release()
+            except (RuntimeError):
+                pass
+        shutil.rmtree(self.tempdir)
+
+    def test_project_default(self):
+        self.assertTrue(self.projects.current)
+        self.assertEqual(self.current, self.projects.current)
+        self.assertTrue(check_dir(self.projects.dir.absolute()))
+        self.assertTrue(check_dir(self.projects.logs_dir.absolute()))
+        self.assertEqual(len(self.projects), 2)
+        self.assertTrue("default" in self.projects)
+
+    def test_create_project(self):
+        self.assertEqual(len(self.projects), 2)
+        self.projects.create_project("a-new-project")
+        self.assertEqual(len(self.projects), 3)
+        self.assertNotEqual(projects.current, "a-new-project")
+        self.assertTrue("a-new-project" in self.projects)
+
+    def test_set_current(self):
+        new_project_name = "".join(random.choices(string.ascii_lowercase, k=18))
+        self.assertNotEqual(projects.current, new_project_name)
+        self.assertFalse(
+            check_dir(
+                f"{self.projects._base_data_dir}/{safe_filename(new_project_name)}"
+            )
+        )
+        self.projects.set_current(new_project_name)
+        self.assertTrue(
+            check_dir(
+                f"{self.projects._base_data_dir}/{safe_filename(new_project_name)}"
+            )
+        )
+
+    @unittest.skip("Don't run this test. It will clean up existing projects")
+    def test_project_creation(self):
+        """No arguments, initializing project instance"""
+        projects = ProjectManager()
+        self.assertGreater(len(projects), 1)
+        self.assertEqual(projects.current, "default")
+        shutil.rmtree(projects.dir)
+
+    @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_windows_path(self):
+        """Logic to confirm we handle windows path length limitation"""
+        pass
+
+    def test_project_folder(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            projects = ProjectManager(tmpdirname)
+            self.assertEqual(projects.current, "default")
+            self.assertEqual(len(projects), 1)
+            self.assertTrue(check_dir(projects.dir))
+            self.assertTrue(projects.dir.is_relative_to(tmpdirname))
+
+    def test_project_with_folder_priority(self):
+        """Pass folder argument and confirm ENV variable doesn't get used"""
+        os.environ["BRIGHTWAY_DIR"] = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            projects = ProjectManager(tmpdirname)
+            self.assertEqual(projects.current, "default")
+            self.assertEqual(len(projects), 1)
+            self.assertTrue(check_dir(projects.dir))
+            self.assertTrue(projects.dir.is_relative_to(tmpdirname))
+            self.assertFalse(projects.dir.is_relative_to(os.getenv("BRIGHTWAY_DIR")))
+            self.assertFalse(
+                check_dir(f"{os.getenv('BRIGHTWAY_DIR')}/{safe_filename('default')}")
+            )
+            del os.environ["BRIGHTWAY_DIR"]
+
+    def test_project_with_env_variable(self):
+        """Pass folder argument and confirm ENV variable doesn't get used"""
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            os.environ["BRIGHTWAY_DIR"] = tmpdirname
+            projects = ProjectManager()
+            self.assertTrue(
+                check_dir(f"{os.getenv('BRIGHTWAY_DIR')}/{safe_filename('default')}")
+            )
+            self.assertEqual(projects.current, "default")
+            self.assertEqual(len(projects), 1)
+            self.assertTrue(check_dir(projects.dir))
+            self.assertTrue(projects.dir.is_relative_to(tmpdirname))
+            del os.environ["BRIGHTWAY_DIR"]
+
+    def test_multiple_projects_different_location(self):
+        folder_1 = "".join(random.choices(string.ascii_lowercase, k=8))
+        self.assertFalse(check_dir(folder_1))
+        project_1 = ProjectManager(folder_1)
+        self.assertEqual(project_1.current, "default")
+
+        folder_2 = "".join(random.choices(string.ascii_lowercase, k=8))
+        self.assertFalse(check_dir(folder_2))
+        project_2 = ProjectManager(folder_2)
+        self.assertEqual(project_2.current, "default")
+
+        self.assertNotEqual(
+            project_1._base_data_dir.as_posix(), project_2._base_data_dir.as_posix()
+        )
+
+        # Cleanup
+        self.assertIn(folder_1, project_1._base_data_dir.as_posix())
+        shutil.rmtree(project_1._base_data_dir)
+        self.assertIn(folder_2, project_2._base_data_dir.as_posix())
+        shutil.rmtree(project_2._base_data_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR will:
- [x] Add `folder` argument to `ProjectManagement` to point it to use a custom folder
- [x] Prioritize `folder` -> `BRIGHTWAY_DIR` -> `appdir` and it will always return a location that is appropriate. **breaking change**, in earlier version, it would raise an `OSError` in case the `ENV` directory didn't exist.
- [x] Take cue from `bw_processing` and include the method of `safe_filename`  into the project to not have any outside dependency on brightway projects
- [x] Instead of using `wrapt` for pytests, use [`tmpdir`](https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html) approach to create temporary folders and use them for the unittests 

## Need inputs on

We still have some logic that handles [`full_hash`](https://github.com/baali/bw_projects/blob/main/bw_projects/project.py#L277), do we need it? If yes, what would be the use cases? 

closes #12 